### PR TITLE
Modification finale pour correspondre à la correction

### DIFF
--- a/src/main/java/fr/esiea/ex4A/mockmeet/MockMeetController.java
+++ b/src/main/java/fr/esiea/ex4A/mockmeet/MockMeetController.java
@@ -33,7 +33,7 @@ public class MockMeetController {
     
     @GetMapping(path = "api/matches", produces = MediaType.APPLICATION_JSON_VALUE)
     List<Match> getMatches(@RequestParam("userName") String name, @RequestParam("userCountry") String country,
-                           @RequestParam("sex") String sexe,@RequestParam("sexPref") String sexePref){
+                           @RequestParam(value = "sex", defaultValue = "null") String sexe,@RequestParam(value = "sexPref", defaultValue = "null") String sexePref){
         if(!apiService.userAlreadyRegistered(name, country))
             return new MatchesResponse();
         if(!sexe.equals("null") && !sexePref.equals("null"))

--- a/src/main/java/fr/esiea/ex4A/mockmeet/tools/ApiService.java
+++ b/src/main/java/fr/esiea/ex4A/mockmeet/tools/ApiService.java
@@ -52,15 +52,8 @@ public class ApiService {
     }
     
     public MatchesResponse getMatchsFor(String name, String country_id){
-        int age = userStocks.getUserAgify(name, country_id).age;
-        MatchesResponse res = new MatchesResponse(getMatches(age));
-        for(int i = 1; i < AGE_SEARCH_LIMIT; i++){
-            res.addAll(getMatches(age + i));
-            res.addAll(getMatches(age - i));
-            if(res.size() >= MATCHES_SEARCH_LIMIT)
-                break;
-        }
-        return res;
+        User user = userStocks.getFirstUserOfUserAgify(userStocks.getUserAgify(name, country_id));
+        return getMatchsFor(user.userName, user.userCountry, user.userSex, user.userSexPref);
     }
     
     private List<Match> getMatches(int age, Sexes sexe, Sexes sexePref){
@@ -69,14 +62,6 @@ public class ApiService {
             users.addAll(users2);
             return users;
         }).get().stream().filter(u -> (u.userSex.equals(sexePref) && u.userSexPref.equals(sexe))).map(User::toMatch).collect(Collectors.toList());
-    }
-    
-    private List<Match> getMatches(int age){
-        List<List<User>> usersOfAge = userStocks.getUsersOfAge(age);
-        return usersOfAge == null ? new ArrayList<>() : usersOfAge.stream().reduce((users, users2) -> {
-            users.addAll(users2);
-            return users;
-        }).get().stream().map(User::toMatch).collect(Collectors.toList());
     }
     
 }

--- a/src/main/java/fr/esiea/ex4A/mockmeet/tools/UserStocks.java
+++ b/src/main/java/fr/esiea/ex4A/mockmeet/tools/UserStocks.java
@@ -49,6 +49,10 @@ public class UserStocks {
         return nameToAUser.get(name.concat("_").concat(contry_id));
     }
     
+    public User getFirstUserOfUserAgify(UserAgify userAgify){
+        return nameToUser.get(userAgify).get(0);
+    }
+    
     // Check if this user has already a corresponding UserAgify in cache
     public boolean userAlreadyExist(User user){
         return nameToAUser.containsKey(makeUserID(user));

--- a/src/test/java/fr/esiea/ex4A/mockmeet/tools/ApiServiceTest.java
+++ b/src/test/java/fr/esiea/ex4A/mockmeet/tools/ApiServiceTest.java
@@ -26,7 +26,8 @@ class ApiServiceTest {
     @Order(1)
     @CsvSource({
         "Hugo,FR,brig@esiea.fr,BriTwtr,F,M,0",
-        "Manon,FR,renaud@virus.debout,RenaudColere,M,F,1"
+        "Manon,FR,renaud@virus.debout,RenaudColere,M,F,1",
+        "Manon,FR,renaud@virus.deboutencore,RenaudColere2,M,F,1"
     })
     void apiService_ajout_test(String name, String country, String mail, String tweeter, String sex, String sexPref, int nbMatchs) {
         
@@ -42,11 +43,13 @@ class ApiServiceTest {
     @ParameterizedTest
     @Order(2)
     @CsvSource({
-        "Hugo,FR,brig@esiea.fr,BriTwtr,F,M,1",
-        "Manon,FR,renaud@virus.debout,RenaudColere,M,F,1"
+        "Hugo,FR,brig@esiea.fr,BriTwtr,F,M,2",
+        "Manon,FR,renaud@virus.debout,RenaudColere,M,F,1",
+        "Manon,FR,renaud@virus.deboutencore,RenaudColere2,M,F,1"
     })
     void apiService_match_test(String name, String country, String mail, String tweeter, String sex, String sexPref, int nbMatchs) {
         
+        assertTrue(api.userAlreadyRegistered(name, country));
         assertEquals(api.getMatchsFor(name, country, Sexes.valueOf(sex), Sexes.valueOf(sexPref)).size(), nbMatchs);
         
     }
@@ -55,10 +58,12 @@ class ApiServiceTest {
     @Order(3)
     @CsvSource({
         "Hugo,FR,brig@esiea.fr,BriTwtr,F,M,2",
-        "Manon,FR,renaud@virus.debout,RenaudColere,M,F,2"
+        "Manon,FR,renaud@virus.debout,RenaudColere,M,F,1",
+        "Manon,FR,renaud@virus.deboutencore,RenaudColere2,M,F,1"
     })
     void apiService_match_noPref_test(String name, String country, String mail, String tweeter, String sex, String sexPref, int nbMatchs) {
         
+        assertTrue(api.userAlreadyRegistered(name, country));
         assertEquals(api.getMatchsFor(name, country).size(), nbMatchs);
         
     }


### PR DESCRIPTION
- On assume désormais les préférences et le sexe de quelqu'un pour lequel on n'a pas cette information (appel préfait de la correction) en utilisant la première occurrence de User ayant ce nom dans le cache.
- Passage de 10 -> 4 ans de limite de recherche pour les matchs (pour correspondre aux matchs attendu de la correction)
- Modification des test de ApiServiceTest afin de tester l'ajout de deux personnes du même nom, ainsi que de tester la fonction 'userAlreadyRegistered'.
